### PR TITLE
remove run_loop from template_manifest.json

### DIFF
--- a/packages/flutter_tools/templates/template_manifest.json
+++ b/packages/flutter_tools/templates/template_manifest.json
@@ -135,8 +135,6 @@
         "templates/app_shared/windows.tmpl/runner/resources/app_icon.ico.img.tmpl",
         "templates/app_shared/windows.tmpl/runner/runner.exe.manifest",
         "templates/app_shared/windows.tmpl/runner/Runner.rc.tmpl",
-        "templates/app_shared/windows.tmpl/runner/run_loop.cpp",
-        "templates/app_shared/windows.tmpl/runner/run_loop.h",
         "templates/app_shared/windows.tmpl/runner/utils.cpp",
         "templates/app_shared/windows.tmpl/runner/utils.h",
         "templates/app_shared/windows.tmpl/runner/win32_window.cpp",


### PR DESCRIPTION

As known from https://github.com/flutter/flutter/pull/79969, the run_loop.h and run_loop.cpp files have been removed.
So we need to remove the run_loop.h and run_loop.cpp files from template_manifest.json.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
